### PR TITLE
Position info fix: avoid using previous token

### DIFF
--- a/lib/treehugger/js/uglifyparser.js
+++ b/lib/treehugger/js/uglifyparser.js
@@ -841,7 +841,7 @@ function parse($TEXT, exigent_mode, embed_tokens) {
                 register_error("Parse error");
                 return ["ERROR"];
             }
-            ast[0] = add_tokens(ast[0], start, prev());
+            ast[0] = add_tokens(ast[0], start, start === S.token ? start : prev());
             return ast;
         };
         else return parser;


### PR DESCRIPTION
This fixes a position info problem where a tree node node could be assigned a starting and ending token where the ending token occurs before the starting one.

It's a small patch, that simply checks if the starting token is the same as the current token. If it is the same, the parser shouldn't use the previous token as the ending token.

@ajaxorg/liskov 
