### PR TITLE
fix cache skipping for rules>200 characters

### DIFF
--- a/lib/treehugger/tree.js
+++ b/lib/treehugger/tree.js
@@ -596,7 +596,7 @@ function parseCached (s) {
         return null;
     }
     if(s.length > 200) {
-        return parse();
+        return parse(s);
     }
     return parseCache[s] || (parseCache[s] = parse(s));
 }


### PR DESCRIPTION
Fix for undefined variable when not passing 's' to parse()
at https://github.com/ajaxorg/treehugger/blob/master/lib/treehugger/tree.js#L599
