### PR TITLE
Fix example code for constructing ASTs.

### DIFF
--- a/lib/treehugger/tree.js
+++ b/lib/treehugger/tree.js
@@ -60,9 +60,9 @@ Node.prototype.findNode = function(pos) {
  * 
  * Example: Add(Num("1"), Num("2")) is constucted
  *    using new ConsNode(new ConsNode("Num", [new StringNode("1")]),
- *                                         new ConsNode("Num", [new StringNode("2")]))
- *    or, more briefly:
- *        tree.cons("Add", [tree.cons("Num", [ast.string("1"), ast.string("2")])])
+ *                       new ConsNode("Num", [new StringNode("2")]))
+ *    or, equivalently:
+ *        tree.cons("Add", [tree.cons("Num", [tree.string("1")]) , tree.cons("Num", [tree.string("2")])])
  */
 function ConsNode(cons, children) {
     this.cons = cons;


### PR DESCRIPTION
Fixed the second example so it produces the same AST as the first. Also, I figured out that the variable `ast` was just the same as `tree`.

Didn't do this, but the second example could also be formatted like the first to more clearly show the structure of the calls.